### PR TITLE
ユーザーアイコンをクリックした時にCVに遷移出来ない不具合を修正

### DIFF
--- a/src/components/MembersCardList.tsx
+++ b/src/components/MembersCardList.tsx
@@ -60,7 +60,7 @@ const MembersCardList = () => {
           <Grid item key={member.githubUserName} xs={12} md={6}>
             <CardActionArea
               component="a"
-              href={`https://github.com/${member.githubUserName}`}
+              href={member.cvUrl}
             >
               <Card className={classes.card}>
                 <div className={classes.cardDetails}>
@@ -68,16 +68,13 @@ const MembersCardList = () => {
                     <Typography component="h2" variant="h5">
                       {member.githubUserName}
                     </Typography>
-                    <Typography variant="subtitle1" color="primary">
-                      {member.cvUrl}
-                    </Typography>
                   </CardContent>
                 </div>
                 <Hidden>
                   <CardMedia
                     className={classes.cardMedia}
                     image={member.githubPicture}
-                    title="Image title"
+                    title={member.githubUserName}
                   />
                 </Hidden>
               </Card>


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/portfolio-frontend/issues/13

# 関連URL
http://localhost:3000/

# Doneの定義
- MemberCardComponentの遷移先がCV用のGitHubリポジトリになっている事

# スクリーンショット
<img width="585" alt="MemberCardComponent" src="https://user-images.githubusercontent.com/11032365/60244252-f87e9c00-98f4-11e9-9751-790fc65d091e.png">

# 変更点概要

## 技術的変更点概要
- MemberCardComponent のリンク先を変更