### PR TITLE
CI用のカバレッジレポートを追加

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -21,25 +21,11 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm install -g yarn
-      - run: yarn install
-      - run: yarn run build
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [12.x]
-    needs: build
-    steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
-      - run: npm install -g yarn
-      - run: yarn install
-      - run: yarn run test:ci
+      - run: |
+          npm install -g yarn
+          yarn install
+          yarn run build
+          yarn run test:ci
       - name: Coveralls
         uses: coverallsapp/github-action@master
         with:

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    name: Build
+    name: Build And Test
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -40,3 +40,7 @@ jobs:
       - run: npm install -g yarn
       - run: yarn install
       - run: yarn run test:ci
+      - name: Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -37,3 +37,7 @@ jobs:
       - run: npm install -g yarn
       - run: yarn install
       - run: yarn run test:ci
+      - name: Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    name: Build
+    name: Build And Test
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -18,25 +18,11 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm install -g yarn
-      - run: yarn install
-      - run: yarn run build
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [12.x]
-    needs: build
-    steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
-      - run: npm install -g yarn
-      - run: yarn install
-      - run: yarn run test:ci
+      - run: |
+          npm install -g yarn
+          yarn install
+          yarn run build
+          yarn run test:ci
       - name: Coveralls
         uses: coverallsapp/github-action@master
         with:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # nekochans-portfolio
+![master](https://github.com/nekochans/portfolio-frontend/workflows/master/badge.svg)
+![develop](https://github.com/nekochans/portfolio-frontend/workflows/develop/badge.svg?branch=develop)
 [![Coverage Status](https://coveralls.io/repos/github/nekochans/portfolio-frontend/badge.svg?branch=master)](https://coveralls.io/github/nekochans/portfolio-frontend?branch=master)
 
 GitHub Organization 「nekochans」の説明用Webサイト

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # nekochans-portfolio
+[![Coverage Status](https://coveralls.io/repos/github/nekochans/portfolio-frontend/badge.svg?branch=master)](https://coveralls.io/github/nekochans/portfolio-frontend?branch=master)
+
 GitHub Organization 「nekochans」の説明用Webサイト
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "test:coverage": "yarn test --coverage --watchAll=false",
-    "test:ci": "CI=true node --max_old_space_size=1024 --trace-gc ./node_modules/react-scripts/bin/react-scripts.js test --env=jsdom --maxWorkers=2",
+    "test:ci": "CI=true node --max_old_space_size=1024 --trace-gc ./node_modules/react-scripts/bin/react-scripts.js test --env=jsdom --maxWorkers=2 --coverage",
     "eject": "react-scripts eject",
     "lint": "eslint --ext ./ 'src/**/*.{js,jsx,ts,tsx}'; stylelint 'src/**/*.css'",
     "format": "eslint --fix --ext ./ 'src/**/*.{js,jsx,ts,tsx}'; stylelint --fix 'src/**/*.css'",


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/portfolio-frontend/issues/67

# Doneの定義
- CIのカバレッジを送信する設定が追加されている事

# 変更点概要
- READMEにカバレッジ用のBadgeを追加
- CoverallsのGitHubActionsを追加しカバレッジを送信するように改修
- 現時点ではjobが分かれていても処理に時間がかかるだけなのでjobを1つに統一

# 補足情報
CI用のGitHubAction用Badgeを追加