### PR TITLE
CIでのテストコードを復活させたのでCoverallsにカバレッジレポートを送信するように変更

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,7 @@ jobs:
           npm run build
           npm run lint
           npm run test:ci
+      - name: Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nekochans-portfolio
 
 [![ci](https://github.com/nekochans/portfolio-frontend/actions/workflows/ci.yml/badge.svg)](https://github.com/nekochans/portfolio-frontend/actions/workflows/ci.yml)
-[![Coverage Status](https://coveralls.io/repos/github/nekochans/portfolio-frontend/badge.svg?branch=develop)](https://coveralls.io/github/nekochans/portfolio-frontend?branch=develop)
+[![Coverage Status](https://coveralls.io/repos/github/nekochans/portfolio-frontend/badge.svg)](https://coveralls.io/github/nekochans/portfolio-frontend)
 
 GitHub Organization 「nekochans」の説明用 Web サイト


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/portfolio-frontend/issues/114

# Done の定義

- CI時にカバレッジレポートが送信されるようになっている事

# 変更点概要

表題の通りです。