### PR TITLE
chromaticの追加

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,3 +7,4 @@ next-env.d.ts
 test/setupTests.ts
 *.config.js
 __mocks__
+storybook-static/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           npm run build
           npm run lint
           npm run test:ci
-          npm run build:storybook
+          npm run build-storybook
       - name: Coveralls
         uses: coverallsapp/github-action@master
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ yarn-error.log*
 
 # env files
 .env
+.envrc
 
 # Storybook
 storybook-static

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ yarn-error.log*
 
 # env files
 .env
+
+# Storybook
+storybook-static
+build-storybook.log

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ build/
 coverage/
 public/googlec001d983b208bd74.html
 __mocks__
+storybook-static/

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@types/styled-components": "^5.1.23",
         "@typescript-eslint/eslint-plugin": "^5.12.1",
         "@typescript-eslint/parser": "^5.12.1",
+        "chromatic": "^6.5.4",
         "eslint": "8.10.0",
         "eslint-config-next": "12.1.0",
         "eslint-config-prettier": "^8.4.0",
@@ -13389,6 +13390,17 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/chromatic": {
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-6.5.4.tgz",
+      "integrity": "sha512-/yunI/+rdc56C6x0IhpPmdfK/DRMOvQ2hoNyAe6uuU9rdWRoAH72lYatr2NcpdsOdHGOcV5DKgIaKgVdPfUk1w==",
+      "dev": true,
+      "bin": {
+        "chroma": "bin/main.cjs",
+        "chromatic": "bin/main.cjs",
+        "chromatic-cli": "bin/main.cjs"
       }
     },
     "node_modules/chrome-trace-event": {
@@ -41500,6 +41512,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true
+    },
+    "chromatic": {
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-6.5.4.tgz",
+      "integrity": "sha512-/yunI/+rdc56C6x0IhpPmdfK/DRMOvQ2hoNyAe6uuU9rdWRoAH72lYatr2NcpdsOdHGOcV5DKgIaKgVdPfUk1w==",
       "dev": true
     },
     "chrome-trace-event": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "test:coverage": "jest --collect-coverage",
     "test:ci": "jest --runInBand --collect-coverage",
     "storybook": "start-storybook -s ./public -p 6006",
-    "build-storybook": "build-storybook -s public"
+    "build-storybook": "build-storybook -s public",
+    "chromatic": "chromatic --project-token=$CHROMATIC_PROJECT_TOKEN"
   },
   "dependencies": {
     "extensible-custom-error": "^0.0.7",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@types/styled-components": "^5.1.23",
     "@typescript-eslint/eslint-plugin": "^5.12.1",
     "@typescript-eslint/parser": "^5.12.1",
+    "chromatic": "^6.5.4",
     "eslint": "8.10.0",
     "eslint-config-next": "12.1.0",
     "eslint-config-prettier": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:coverage": "jest --collect-coverage",
     "test:ci": "jest --runInBand --collect-coverage",
     "storybook": "start-storybook -s ./public -p 6006",
-    "build:storybook": "build-storybook -o build/storybook"
+    "build-storybook": "build-storybook -s public"
   },
   "dependencies": {
     "extensible-custom-error": "^0.0.7",


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/portfolio-frontend/issues/164

# 関連 URL

なし

# Done の定義

- `chromatic` の設定と必要なpackageが追加されている事

# スクリーンショット

なし

# 変更点概要

`chromatic` にStorybookをデプロイする為の設定を追加。

https://zenn.dev/keitakn/articles/storybook-deploy-to-chromatic#storybook%E3%81%AEbuild-%E3%82%B9%E3%82%AF%E3%83%AA%E3%83%97%E3%83%88%E5%90%8D%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6 に書いてある通りStorybookのbuild スクリプト名をデフォルトに変更した。

# レビュアーに重点的にチェックして欲しい点

なし

# 補足情報

なし