### PR TITLE
コミット毎にchromaticにStorybookをデプロイするワークフローを追加

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,21 @@
+name: chromatic
+
+on: push
+
+jobs:
+  chromatic-deployment:
+    name: Deploy Storybook to chromatic
+    runs-on: ubuntu-latest
+    timeout-minutes: 7
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Install dependencies
+        run: npm ci
+      - name: Publish to Chromatic
+        uses: chromaui/action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/portfolio-frontend/issues/164

# 関連 URL

なし

# Done の定義

- コミット毎にStorybookがデプロイされるようになっている事

# スクリーンショット

なし

# 変更点概要

表題の通り。

https://zenn.dev/keitakn/articles/storybook-deploy-to-chromatic#github-actions-%E3%81%A7-chromatic%E3%81%B8%E3%81%AE%E3%83%87%E3%83%97%E3%83%AD%E3%82%A4%E3%82%92%E8%87%AA%E5%8B%95%E5%8C%96%E3%81%99%E3%82%8B を参考にした「。

# レビュアーに重点的にチェックして欲しい点

なし

# 補足情報

なし